### PR TITLE
The Atreus now uses QMK as its official firmware.

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,6 +11,7 @@ This is a keyboard firmware based on the [tmk\_keyboard firmware](http://github.
 * [ErgoDox EZ](https://github.com/qmk/qmk_firmware/blob/master/keyboards/ergodox_ez/)
 * [Clueboard](https://github.com/qmk/qmk_firmware/blob/master/keyboards/clueboard/)
 * [Cluepad](https://github.com/qmk/qmk_firmware/blob/master/keyboards/clueboard/17/)
+* [Atreus](https://github.com/qmk/qmk_firmware/blob/master/keyboards/atreus/)
 
 These projects use QMK as their official and default firmware - is yours missing from the list? [Let us know!](https://github.com/qmk/qmk.fm/issues/new) 
 


### PR DESCRIPTION
See https://github.com/technomancy/atreus/commit/c8a393a827bf661fd075d0a6fbff76183c934de3

Thanks!