### PR TITLE
2019 Week 4 Commit changes update

### DIFF
--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -2,3 +2,5 @@ keyboards:
   color: blue
 core:
   color: red
+split:
+  color: green

--- a/_pages/categories/split.md
+++ b/_pages/categories/split.md
@@ -1,0 +1,6 @@
+---
+title: "All recent changes to the Split Keyboard code in QMK "
+layout: qmk-category
+permalink: /changes/split/
+category: split
+---

--- a/_posts/2018-02-16-fix-eehands-on-splits-losing-handedness-if-rgb-is-enabled.md
+++ b/_posts/2018-02-16-fix-eehands-on-splits-losing-handedness-if-rgb-is-enabled.md
@@ -2,7 +2,7 @@
 layout: qmk-title
 title: "Fix EE HANDS on splits losing handedness if RGB is enabled"
 date: 2018-02-16 00:00:00 -0500
-category: core
+category: split
 commit: b0e8de1
 pr: 2399
 ---

--- a/_posts/2018-06-17-split-common.md
+++ b/_posts/2018-06-17-split-common.md
@@ -2,7 +2,7 @@
 layout: qmk-title
 title: "Split Common"
 date: 2018-06-17 00:00:00 -0500
-category: core
+category: split
 commit: a012113
 pr: 3429
 ---

--- a/_posts/2018-12-04-keyboard-add-new-keyboard-sol-from-rgbkb.md
+++ b/_posts/2018-12-04-keyboard-add-new-keyboard-sol-from-rgbkb.md
@@ -1,6 +1,6 @@
 ---
 layout: qmk-title
-title: "Keyboard: Add new keyboard "Sol" from RGBKB"
+title: "Keyboard: Add new keyboard Sol from RGBKB"
 date: 2018-12-04 18:16:00 -0800
 category: keyboards
 commit: 8a330b3 

--- a/_posts/2018-12-05-keyboard-initial-i75-port.md
+++ b/_posts/2018-12-05-keyboard-initial-i75-port.md
@@ -1,4 +1,3 @@
-
 ---
 layout: qmk-title
 title: "Keyboard: Initial i75 port"

--- a/_posts/2018-12-14-make-quantum-split_common-serial-ch-configurable.md
+++ b/_posts/2018-12-14-make-quantum-split_common-serial-ch-configurable.md
@@ -2,7 +2,7 @@
 layout: qmk-title
 title: "Make quantum/split_common/serial.[ch] configurable"
 date: 2018-12-14 00:00:00 -0500
-category: core
+category: split
 commit: 155e931 
 pr: 4419
 ---

--- a/_posts/2018-12-14-refactor-quantum-split_common-i2c-c-quantum-split_common-serial-c.md
+++ b/_posts/2018-12-14-refactor-quantum-split_common-i2c-c-quantum-split_common-serial-c.md
@@ -2,7 +2,7 @@
 layout: qmk-title
 title: "Refactor quantum/split_common/i2c.c, quantum/split_common/serial.c"
 date: 2018-12-14 00:00:00 -0500
-category: core
+category: split
 commit:  8f79094
 pr: 4522
 ---

--- a/_posts/2018-12-24-replace-serial-c-of-quantum-split_common.md
+++ b/_posts/2018-12-24-replace-serial-c-of-quantum-split_common.md
@@ -2,7 +2,7 @@
 layout: qmk-title
 title: "Replace serial.c of quantum/split_common/"
 date: 2018-12-24 00:00:00 -0500
-category: core
+category: split
 commit:  72d4e4b 
 pr: 4669
 ---

--- a/_posts/2019-01-01-change-rgblight-get-mode-rgb-matrix-get-modes-return-type-to-uint8-t.md
+++ b/_posts/2019-01-01-change-rgblight-get-mode-rgb-matrix-get-modes-return-type-to-uint8-t.md
@@ -1,0 +1,14 @@
+---
+layout: qmk-title
+title: "Change rgblight_get_mode & rgb_matrix_get_mode's return type to uint8_t"
+date: 2019-01-01 00:00:00 -0500
+category: core
+commit: b768859
+pr: 4747
+---
+
+`rgblight_get_mode()`'s return type right now is `uint32_t`, but upon inspection of its implementation, it's actually returning `rgblight_config_t.mode`, which is an `uint8_t`.  The return type should match `rgblight_config_t.mode`'s.  
+
+I've grep'd through all the keymaps, there does seem to be a few places where `rgblight_get_mode`'s return value is being saved into another uint32_t variable.  These are probably be OK as they're just upcasting.
+
+Also updating `rgb_matrix_get_mode` to return `uint8_t` for similar reason.

--- a/_posts/2019-01-03-convert-split-common-to-use-generic-gpio-api.md
+++ b/_posts/2019-01-03-convert-split-common-to-use-generic-gpio-api.md
@@ -1,0 +1,10 @@
+---
+layout: qmk-title
+title: "Convert split_common to use generic GPIO api"
+date: 2019-01-03 00:00:00 -0500
+category: split
+commit: 38e01a7
+pr: 4757
+---
+
+This is a small but important step to converting the Split Keyboard code to be ARM compatible, by using hardware agnostic functions (instead of the AVR specific addresses).

--- a/_posts/2019-01-03-remove-redundant-language-specific-aliases-for-kc-algr.md
+++ b/_posts/2019-01-03-remove-redundant-language-specific-aliases-for-kc-algr.md
@@ -1,0 +1,10 @@
+---
+layout: qmk-title
+title: "Remove redundant, language-specific aliases for KC_ALGR"
+date: 2019-01-03 00:00:00 -0500
+category: core
+commit: e76bf17
+pr: 4720
+---
+
+Removes redundant, language-specific aliases for KC_ALGR, since that keycode is standard now.

--- a/_posts/2019-01-07-improve-consistency-in-unicodemap-code-and-docs-update-docs-understanding-qmk.md
+++ b/_posts/2019-01-07-improve-consistency-in-unicodemap-code-and-docs-update-docs-understanding-qmk.md
@@ -1,0 +1,13 @@
+---
+layout: qmk-title
+title: "Improve consistency in UNICODEMAP code and docs, update docs/understanding_qmk"
+date: 2019-01-07 00:00:00 -0500
+category: core
+commit: cd9262d
+pr: 4774
+---
+
+
+Rename some constants and functions pertaining to UNICODEMAP so they're consistent with the rest of the system. Also update the documentation accordingly. See below for details.
+
+These changes should be non-breaking. I've taken care to update all usages of the renamed symbols.

--- a/_posts/2019-01-07-update-to-arm-atsam-wait-and-timer-routines.md
+++ b/_posts/2019-01-07-update-to-arm-atsam-wait-and-timer-routines.md
@@ -1,0 +1,20 @@
+---
+layout: qmk-title
+title: "Update to arm_atsam wait and timer routines"
+date: 2019-01-07 00:00:00 -0500
+category: core
+commit: 6e984a8
+pr: 4680
+---
+
+This update is to get the arm_atsam branch timer and wait functions aligned with common QMK functions. It also includes a much simpler, rewritten method to microsecond delays to tighten timings. This update affects Massdrop's CTRL and ALT keyboards, and they have both been thoroughly tested.
+
+Microsecond (us) delays are now handled by a busy wait loop according to MCU frequency. This replaces the system counter method which had an overhead of around 12us. The new method has an overhead less than 0.5us.
+`TC5` device and supporting routines removed as it was the old us delay counter.
+`wait_ms()` is now properly a macro to `CLK_delay_ms()`.
+`wait_us()` is now properly a macro to `CLK_delay_us()`.
+Removed `CLK_get_us()` as it has no use.
+All calls to `CLK_get_ms()` have been replaced by `timer_read64()` with corrected typing.
+All calls to `CLK_delay_ms()` have been replaced by `wait_ms()`.
+All calls to `CLK_delay_us()` have been replaced by `wait_us()` and timings verified and updated as needed after review on scope.
+Corrected typing of variables using 64bit ms timer readings if needed.

--- a/_posts/2019-01-10-add-proton-c-conversion.md
+++ b/_posts/2019-01-10-add-proton-c-conversion.md
@@ -1,0 +1,28 @@
+---
+layout: qmk-title
+title: "Adds Proton C Conversion"
+date: 2019-01-10 00:00:00 -0500
+category: core
+commit: 3cf179b 
+pr: 4661
+---
+
+If a board currently supported in QMK uses a Pro Micro (or compatible board) and you want to use the Proton C, you can generate the firmware by appending `CONVERT_TO_PROTON_C=yes` (or `CTPC=yes`) to your make argument, like this:
+
+    make 40percentclub/mf68:default CTPC=yes
+
+You can add the same argument to your keymap's `rules.mk`, which will accomplish the same thing.
+
+This exposes the `CONVERT_TO_PROTON_C` flag that you can use in your code with `#ifdef`s, like this:
+
+    #ifdef CONVERT_TO_PROTON_C
+        // Proton C code
+    #else
+        // Pro Micro code
+    #endif
+
+Before being able to compile, you may get some errors about `PORTB/DDRB`, etc not being defined, so you'll need to convert the keyboard's code to use the [GPIO Controls](internals_gpio_control.md) that will work for both ARM and AVR. This shouldn't affect the AVR builds at all.
+
+The Proton C only has one on-board LED (C13), and by default, the TXLED (D5) is mapped to it. If you want the RXLED (B0) mapped to it instead, add this like to your `config.h`:
+
+    #define CONVERT_TO_PROTON_C_RXLED

--- a/_posts/2019-01-10-fix-caps-lock-leds-once-and-for-all.md
+++ b/_posts/2019-01-10-fix-caps-lock-leds-once-and-for-all.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "Fix Caps Lock LEDs once and for all"
+date: 2019-01-11 00:00:00 -0500
+category: core
+commit: 2c41093
+pr: 4824
+---
+
+The status LEDs don't light up/light up incorrectly on Linux in certain circumstances. This is because, if NKRO is enabled it will send two LED states, one for the 6KRO interface, and one for the NKRO interface. QMK interprets the NKRO report ID as the LED state and turn on the num lock and scroll lock LEDs.
+
+If we have two bytes, that probably means the first is a report ID. The 6KRO interface may or may not have one, but the NKRO interface always does, so we need to check this regardless of whether `KEYBOARD_SHARED_EP` is defined.

--- a/_posts/2019-01-11-keyboard-adding-support-for-gergo.md
+++ b/_posts/2019-01-11-keyboard-adding-support-for-gergo.md
@@ -1,0 +1,10 @@
+---
+layout: qmk-title
+title: "[Keyboard] Adding support for Gergo"
+date: 2019-01-26 00:00:00 -0500
+category: keyboards
+commit: d8eace3
+pr: 4792
+---
+
+We've added support for the Gergo keyboard from [g Heavy Industries](http://gboards.ca}! 

--- a/_posts/2019-01-13-keyboard-add-support-for-the50.md
+++ b/_posts/2019-01-13-keyboard-add-support-for-the50.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "[Keyboard] Add support for THE50"
+date: 2019-01-26 00:00:00 -0500
+category: keyboards
+commit: ee96b7a
+pr: 4844
+---
+
+We've added support for the THE50 keyboard! 
+
+A 50% custom keyboard designed and produced by [LazyDesigners](http://lazydesigners.cn)

--- a/_posts/2019-01-15-keyboard-add-bthlabs-geekpad.md
+++ b/_posts/2019-01-15-keyboard-add-bthlabs-geekpad.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "[Keyboard] Add bthlabs/geekpad"
+date: 2019-01-26 00:00:00 -0500
+category: keyboards
+commit: 2dcce4c
+pr: 4840
+---
+
+We've added support for the BTHLabs GeekPad macropad! 
+
+A 3x3 custom macro pad designed and developed by Tomek Wójcik.

--- a/_posts/2019-01-17-simplify-split-common-significantly.md
+++ b/_posts/2019-01-17-simplify-split-common-significantly.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "Simplify split_common significantly"
+date: 2019-01-17 00:00:00 -0500
+category: split
+commit: 28929ad
+pr: 4772
+---
+
+Split_common no longer has a separate main loop for the slave, it reuses the keyboard_task main loop like ergodox infinity. This eliminates a lot of the code and makes it a bit easier to reason about. It also means that the slave will behave slightly differently depending on what flags are enabled - many of the options lie outside the is_keyboard_master gate in keyboard_task, and I expect that will have to change as they're tested.
+
+The master/slave transport stuff has also been slighly refactored - instead of i2c_* and serial_* functions and a bunch of ifdefs to change the calling code, it's all been renamed generically, so there's no transport-specific ifdefs in the guts of the matrix code.

--- a/_posts/2019-01-18-keyboard-initial-support-for-tkc-candybar.md
+++ b/_posts/2019-01-18-keyboard-initial-support-for-tkc-candybar.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "[Keyboard] Initial support for TKC Candybar"
+date: 2019-01-18 00:00:00 -0500
+category: keyboards
+commit:  ebec12f
+pr: 4881
+---
+
+We've added support for the TKC Candybar keyboard! 
+
+The Key Company's Candybar is a staggered 40% board with a numpad utilizing the STM32F072 microcontroller.

--- a/_posts/2019-01-20-keyboard-tmo50-initial-commit.md
+++ b/_posts/2019-01-20-keyboard-tmo50-initial-commit.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "[Keyboard] Tmo50 initial commit"
+date: 2019-01-20 00:00:00 -0500
+category: keyboards
+commit: 58993d3
+pr: 4891
+---
+
+We've added support for the TMO50 keyboad! 
+
+The TMO50 is a 50% mechanical keyboard with macro column on the left side. Sub60% board without compromises.

--- a/_posts/2019-01-21-keyboard-added-tgr-alice-keyboard-support.md
+++ b/_posts/2019-01-21-keyboard-added-tgr-alice-keyboard-support.md
@@ -1,0 +1,10 @@
+---
+layout: qmk-title
+title: "[Keyboard] Added TGR Alice keyboard support"
+date: 2019-01-21 00:00:00 -0500
+category: keyboards
+commit: 2cc674c 
+pr: 4896
+---
+
+We've added support for the TGR Alice keyboard! 

--- a/_posts/2019-01-23-keyboard-add-bdn9-macropad.md
+++ b/_posts/2019-01-23-keyboard-add-bdn9-macropad.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "[Keyboard] Add BDN9"
+date: 2019-01-23 00:00:00 -0500
+category: keyboards
+commit: 87ab49e
+pr: 4919
+---
+
+We've added support for the [Keebio](https://keeb.io/) [BDN9](https://keeb.io/products/bdn9-3x3-9-key-macropad-rotary-encoder-support) macropad! 
+
+A 3x3 macropad with support for a rotary encoder at the upper two corners.

--- a/_posts/2019-01-23-keyboard-kbd67-hotswap-support.md
+++ b/_posts/2019-01-23-keyboard-kbd67-hotswap-support.md
@@ -1,0 +1,10 @@
+---
+layout: qmk-title
+title: "[Keyboard] Add KBD67 Hotswap Support"
+date: 2019-01-23 00:00:00 -0500
+category: keyboards
+commit: fafb33d 
+pr: 4916
+---
+
+We've added support for the 

--- a/_posts/2019-01-25-add-mod-mask-macro-to-core-code.md
+++ b/_posts/2019-01-25-add-mod-mask-macro-to-core-code.md
@@ -1,0 +1,15 @@
+---
+layout: qmk-title
+title: "Add MOD_MASK_* macros to core code"
+date: 2019-01-25 00:00:00 -0500
+category: core
+commit:  2f009d7
+pr: 4337
+---
+
+This adds the Mod MASK ans pre-existing defines in the core code, so you can easily reference them without having to manually define them.
+
+These are different from `MOD_*`, and cannot be used interchangeably.  For details, see these links: 
+
+* `MOD_MASK_*`: https://github.com/qmk/qmk_firmware/pull/4337#issuecomment-447507781
+* `MOD_*`: https://github.com/qmk/qmk_firmware/pull/4337#issuecomment-447507781

--- a/_posts/2019-01-25-fix-osm-mod-problem.md
+++ b/_posts/2019-01-25-fix-osm-mod-problem.md
@@ -1,0 +1,10 @@
+---
+layout: qmk-title
+title: "Fix OSM(mod) problem"
+date: 2019-01-25 00:00:00 -0500
+category: core
+commit: 3c0c432
+pr: 3651
+---
+
+This fixes an issue with One Shot Mods not properly respecting the Magic ALT-GUI Swap setting.

--- a/_posts/2019-01-25-fix-rgblight-sleep-function.md
+++ b/_posts/2019-01-25-fix-rgblight-sleep-function.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "Fix RGBLIGHT_SLEEP function"
+date: 2019-01-25 00:00:00 -0500
+category: core
+commit: 7aba1fd 
+pr: 4865
+---
+
+This fixxes the `RGBLIGHT_SLEEP` option, so that the lights properly maintain the previous setting in all cases.
+
+Previously, it would effectively force the lights to be on, regardless of the previous status.  This is entirely drashna's fault (as admitted by him, and this excerpt is written by him) since it was never properly tested with the lights off.

--- a/_posts/2019-01-26-adds-a-default-value-for-is-command-for-command-feature.md
+++ b/_posts/2019-01-26-adds-a-default-value-for-is-command-for-command-feature.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "Adds a default value for IS_COMMAND for COMMAND feature"
+date: 2019-01-26 00:00:00 -0500
+category: core
+commit: b05c0e4 
+pr: 4301
+---
+
+This adds a default value for IS_COMMAND to the core code.  This is so that each keyboard doesn't have to define it locally.  It only has to define it, if it is not the default.
+
+THis has some added advantages, like making it easy to fix the the "keyboard_report->mods" value no longer working properly for this, after the endpoint consolidation commit.

--- a/_posts/2019-01-26-update-preonics-mcu-configuration-to-use-the-built-ins.md
+++ b/_posts/2019-01-26-update-preonics-mcu-configuration-to-use-the-built-ins.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "Update Preonic's MCU configuration to use the built-ins"
+date: 2019-01-26 00:00:00 -0500
+category: keyboards
+commit: 8da9d33
+pr: 4941
+---
+
+This updates the Preonic keyboard configuration to use the built ARM MCU code.
+
+This fixes issues with dual action keys not working properly. 

--- a/_posts/2019-01-27-fix-command-feature-use-get-mods-instead-of-keyboard-report-mods.md
+++ b/_posts/2019-01-27-fix-command-feature-use-get-mods-instead-of-keyboard-report-mods.md
@@ -1,0 +1,18 @@
+---
+layout: qmk-title
+title: "Fix Command feature: use get_mods() instead of keyboard_report->mods"
+date: 2019-01-26 00:00:00 -0500
+category: core
+commit: 4d9b11a
+pr: 4955
+---
+
+This replaces `keyboard_report->mods` with `get_mods()` instead, for the `IS_COMMAND` call, since it was broken due to issues with the Endpoint Consolidation commit.
+
+As discussed in #4838, the Command feature doesn't work when NKRO is turned on since the keyboard report structure is different. get_mods() is the proper way to retrieve mod state. See issue for further details.
+
+We've only replaced occurrences of keyboard_report->mods in IS_COMMAND definitions and Massdrop keyboard code (as per @patrickmt's comment on the issue). It's likely that other occurrences in keyboard code and user keymaps can be replaced as well, but We didn't want to do that in this PR as it could require more extensive testing.
+
+Additionally, We removed an unnecessary IS_COMMAND redefinition in keyboards/clueboard/66/rev4/config.h which we missed in #4301.
+
+Thanks @fauxpark for helping me figure out what was causing the problems with Command!

--- a/_posts/2019-01-27-keyboard-unigo66-keyboard-added.md
+++ b/_posts/2019-01-27-keyboard-unigo66-keyboard-added.md
@@ -1,0 +1,12 @@
+---
+layout: qmk-title
+title: "[Keyboard] UniGo66 keyboard added"
+date: 2019-01-27 00:00:00 -0500
+category: keyboards
+commit: 9ae800f
+pr: 4913
+---
+
+We've added support for the UniGo66 keyboard! 
+
+The UniGo66 is an ergonomic wireless keyboard designed by Sirius and manufactured by ALF Studios.


### PR DESCRIPTION
This adds a new category for "split" keyboards, so that people can watch the progress of the ARM support for split keyboards.