### PR TITLE
Fix qmk.fm/keyboards/ page

### DIFF
--- a/_util/generate_keyboard_page.sh
+++ b/_util/generate_keyboard_page.sh
@@ -14,7 +14,7 @@ exec 3<>$OUTPUT
 cat _util/keyboards_template.md >&3
 
 while IFS='' read -r line || [[ -n "$line" ]]; do
-    keyboard=${line/\//_}
+    keyboard=${line//\//_}
     if [ -e "compiled/${keyboard}_default.hex" ] || [ -e "compiled/${keyboard}_default.bin" ]; then
         echo -n "| <i class='fa fa-github' aria-hidden='true'></i> [${line}](https://github.com/qmk/qmk_firmware/tree/master/keyboards/${line}) | " >&3
 


### PR DESCRIPTION
Existing script failed to list keyboards if the firmware filename included a revision, which affected:

- 40percentclub/i75
- clueboard/66
- clueboard/66_hotswap
- converter/palm_usb
- converter/sun_usb
- converter/usb_usb
- duck/eagle_viper
- duck/octagon
- exclusive/e6v2
- handwired/bluepill
- handwired/dactyl_manuform
- handwired/qc60
- handwired/xealous
- kbdfans/kbd67
- kbdfans/kbd75
- keebio/iris
- keebio/levinson
- keebio/nyquist
- keebio/quefrency
- keebio/rorschach
- keebio/viterbi
- sentraq/s60_x

None of these were previously listed on the Supported Keyboards page.

Solution: double the first slash on Line 17 of _util/generate_keyboard_page.sh, which makes the operation replace *all* forward slashes in `keyboard` with underscores, instead of only the first slash.
