### PR TITLE
Fix typo in gErgo update post

### DIFF
--- a/_posts/2019-01-11-keyboard-adding-support-for-gergo.md
+++ b/_posts/2019-01-11-keyboard-adding-support-for-gergo.md
@@ -7,4 +7,4 @@ commit: d8eace3
 pr: 4792
 ---
 
-We've added support for the Gergo keyboard from [g Heavy Industries](http://gboards.ca}! 
+We've added support for the Gergo keyboard from [g Heavy Industries](http://gboards.ca)! 


### PR DESCRIPTION
There was a closing curly bracket instead of an ending parenthesis, which broke the markdown.