### PR TITLE
Fix broken gitbook link in the front page

### DIFF
--- a/_i18n/en/index.md
+++ b/_i18n/en/index.md
@@ -28,7 +28,7 @@ QMK is developed and maintained by Jack Humbert of OLKB with contributions from 
 
 ## Documentation
 
-[Documentation](https://docs.qmk.fm) is hosted on [Gitbook](https://docs.qmk.fm) and [Github](https://github.com/qmk/qmk_firmware/tree/master/docs) (they are synced). You can request changes by making a fork and [pull request](https://github.com/qmk/qmk_firmware/pulls) or by clicking the "suggest an edit" on any page.
+[The official documentation](https://docs.qmk.fm) is powered by [Docsify](https://docsify.js.org/) and hosted on [GitHub](https://github.com/qmk/qmk_firmware/tree/master/docs). You can request changes by making a fork and [pull request](https://github.com/qmk/qmk_firmware/pulls) or by clicking the "Edit Document" link at the bottom of any page.
 
 ## Configurator
 

--- a/_i18n/en/index.md
+++ b/_i18n/en/index.md
@@ -28,7 +28,7 @@ QMK is developed and maintained by Jack Humbert of OLKB with contributions from 
 
 ## Documentation
 
-[Documentation](https://docs.qmk.fm) is hosted on [Gitbook](https://www.gitbook.com/book/qmk/firmware/details) and [Github](https://github.com/qmk/qmk_firmware/tree/master/docs) (they are synced). You can request changes by making a fork and [pull request](https://github.com/qmk/qmk_firmware/pulls) or by clicking the "suggest an edit" on any page.
+[Documentation](https://docs.qmk.fm) is hosted on [Gitbook](https://docs.qmk.fm) and [Github](https://github.com/qmk/qmk_firmware/tree/master/docs) (they are synced). You can request changes by making a fork and [pull request](https://github.com/qmk/qmk_firmware/pulls) or by clicking the "suggest an edit" on any page.
 
 ## Configurator
 


### PR DESCRIPTION
- Gitbook link pointed into 404 page. Fixed the link based on the link used in German translation.

Should fix the link issue mentioned in https://github.com/qmk/qmk_firmware/issues/7054