### PR TITLE
Fix QMK Toolbox supported bootloaders links

### DIFF
--- a/_i18n/en/toolbox.md
+++ b/_i18n/en/toolbox.md
@@ -10,10 +10,10 @@ This is a collection of useful tools packaged into one app. This is a pretty rec
 ## Flashing
 
 Supporting following bootloaders:
- - DFU (Atmel, LUFA) via dfu-programmer (http://dfu-programmer.github.io/)
- - Caterina (Arduino, Pro Micro) via avrdude (http://nongnu.org/avrdude/)
- - Halfkay (Teensy, Ergodox EZ) via teensy_loader_cli (https://pjrc.com/teensy/loader_cli.html)
- - STM32 (ARM) via dfu-util (http://dfu-util.sourceforge.net/)
+ - DFU (Atmel, LUFA) via [dfu-programmer](http://dfu-programmer.github.io/)
+ - Caterina (Arduino, Pro Micro) via [avrdude](http://nongnu.org/avrdude/)
+ - Halfkay (Teensy, Ergodox EZ) via [teensy_loader_cli](https://pjrc.com/teensy/loader_cli.html)
+ - STM32 (ARM) via [dfu-util](http://dfu-util.sourceforge.net/)
  
 If there's an interest in any, more can be added if their commands are know.
  


### PR DESCRIPTION
The links in the https://qmk.fm/toolbox/ are in just plain text format (as seen bellow).

![image](https://user-images.githubusercontent.com/2406748/67242919-3339b080-f45f-11e9-8fd0-8e9842501b46.png)

## Description

This changes the markdown so that the links should work correctly.

