### PR TITLE
French translation patch

### DIFF
--- a/_i18n/fr/coc.md
+++ b/_i18n/fr/coc.md
@@ -26,7 +26,7 @@ Voici quelques exemples de comportements que nous ne tolérerons pas (liste non 
 
 # Signaler
 
-Si quelqu'un viole ce Code de Conduite, veuillez envoyer un email à hello arobase qmk.fm ou contactez l'un des collaborateur. Toutes les plaintes seront évaluées et prises en considération.
+Si quelqu'un viole ce Code de Conduite, veuillez envoyer un email à hello@qmk.fm ou contactez l'un des collaborateur. Toutes les plaintes seront évaluées et prises en considération.
 
 QMK essaiera d'utiliser le moins possible quelque punition que ce soit pour résoudre un conflit. Si les circonstances requièrent l'exclusion d'un agresseur, nous prendrons les décisions nécessaires.
 

--- a/_i18n/fr/coc.md
+++ b/_i18n/fr/coc.md
@@ -11,7 +11,7 @@ QMK s'efforce d'être une communauté, accueillante, tolérante et inclusive. No
 
 > "Une réponse douce calme la fureur, Mais une parole dure excite la colère."
 
-Nous attendons de nos utilisateurs, contributeurs et collaborateurs qu'ils se traitent avec gentillesse et respect, qu'ils aient de bonnes intentions, de corriger avec pédagogie, quand cela est possible, plutôt que de régir de façon disproportionnée. Même si notre but est d'être aussi précis que possible, la compréhension et la gentillesse sont plus précieuses que l'exactitude.
+Nous attendons de nos utilisateurs, contributeurs et collaborateurs qu'ils se traitent avec gentillesse et respect, qu'ils aient de bonnes intentions, de corriger avec pédagogie, quand cela est possible, plutôt que de réagir de façon disproportionnée. Même si notre but est d'être aussi précis que possible, la compréhension et la gentillesse sont plus précieuses que l'exactitude.
 
 Voici quelques exemples de comportements que nous ne tolérerons pas (liste non exhaustive):
 

--- a/_i18n/fr/coc.md
+++ b/_i18n/fr/coc.md
@@ -7,7 +7,7 @@ lang: fr
 
 # Code de conduite
 
-QMK s'efforce d'être une communauté, accueillante, tolérante et inclusive. Nous encourageons toutes les contributions indépendamment de l'âge, de quelconque handicap, de l'appartenance éthnique, du genre, du niveau d'expérience technique, de la nationalité, de l'apparence physique, des orientations politiques, de la race, de la religion ou de l'orientation et de l'identification sexuelle.
+QMK s'efforce d'être une communauté, accueillante, tolérante et inclusive. Nous encourageons toutes les contributions indépendamment de l'âge, de quelconque handicap, de l'appartenance ethnique, du genre, du niveau d'expérience technique, de la nationalité, de l'apparence physique, des orientations politiques, de la race, de la religion ou de l'orientation et de l'identification sexuelle.
 
 > "Une réponse douce calme la fureur, Mais une parole dure excite la colère."
 

--- a/_i18n/fr/sidebar.md
+++ b/_i18n/fr/sidebar.md
@@ -1,4 +1,4 @@
-Le but du projet QMK est de développer un firmware complètement personnalisable, puissant et facile à utiliser pour tous type de projet de clavier ou autre, et de fournir une aide bienveillante, encourageante et utile ainsi que des retours pour des personnes avec n'import quelle expérience en développement logiciel.
+Le but du projet QMK est de développer un firmware complètement personnalisable, puissant et facile à utiliser pour tous type de projet de clavier ou autre, et de fournir une aide bienveillante, encourageante et utile ainsi que des retours pour des personnes avec n'importe quelle expérience en développement logiciel.
 
 [Voir sur <i class="fa fa-github" aria-hidden="true"></i> GitHub](https://github.com/qmk/qmk_firmware)
 

--- a/_i18n/fr/support.md
+++ b/_i18n/fr/support.md
@@ -16,7 +16,7 @@ lang: fr
 
 * Couvrir les frais des serveurs et d'infrastructure
 * Couvrir les frais de prototypages pour des produits QMK comme le [Proton C](/proton-c/)
-* Envoyer des goodies à des meetups pour offrir ou pour des concours. Envoyez nous un email si vous êtes intéressés ! hello arobase qmk.fm
+* Envoyer des goodies à des meetups pour offrir ou pour des concours. Envoyez nous un email si vous êtes intéressés ! hello@qmk.fm
 * Imprimer des [dépliant informatifs QMK](https://i.imgur.com/EoXgApN.png) pour offrir aux fabricants de clavier (frais optionnels de 0,10$ pour couvrir les frais), envoyez nous un email si vous êtes intéressé !
 
 Vous connaissez un autre moyen d'aider la communauté ? [Faites le nous savoir !](https://github.com/qmk/qmk.fm/issues)


### PR DESCRIPTION
This PR applies suggestions that were not applied in #66.

The suggestions were submitted by:

- @Darkpingouin
  - https://github.com/qmk/qmk.fm/pull/66#issuecomment-545329898
- @zekth 
  - https://github.com/qmk/qmk.fm/pull/66#pullrequestreview-306099237
- @Ph0tonic
  - https://github.com/qmk/qmk.fm/pull/66#pullrequestreview-307544473
  - https://github.com/qmk/qmk.fm/pull/66#pullrequestreview-307544602

I skipped zekth's suggestion regarding changing `s'efforce` to `s'éfforce` because I checked four different French language resources (that I found on duckduckgo) and none of them spelled it with the accent.

The commit signatures on these commits are my own. I'm not out here stealing anyone's identity, I promise. It's important to me that people get their due credit.