### PR TITLE
Build site on PRs to avoid potential deployment issues.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container: jekyll/builder
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: jekyll build
+      run: |
+        gem install bundler:1.14.6
+        jekyll build


### PR DESCRIPTION
Translations recently caused the site to not be updated. This PR aims to catch that type of issue slightly earlier in the review process.

Current build generates the expected error we see right now, can rebase if #116 is merged first.