### PR TITLE
Add a direct link to the documentation in sidebar

### DIFF
--- a/_includes/en_sidebar.md
+++ b/_includes/en_sidebar.md
@@ -19,3 +19,4 @@ The goal of the QMK software project is to develop a completely customizable, po
 * [Code of Conduct](/coc/)
 * [How to support QMK](/support/)
 * [QMK Toolbox](https://github.com/qmk/qmk_toolbox)
+* [Documentation](https://docs.qmk.fm/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Hi,

Thanks for your work :muscle: 

I think the sidebar is missing a direct link to the documentation despite already being in the front page. I think it is hard to find it in the default page.


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Added a link to https://docs.qmk.fm/ to the sidebar

<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
