### PR TITLE
fix 404 links

### DIFF
--- a/_i18n/de/support.md
+++ b/_i18n/de/support.md
@@ -7,7 +7,7 @@ lang: "de"
 
 # QMK unterstützen
 
-* [QMK Fan-Artikel auf olkb.com](https://olkb.com/parts)
+* [QMK Fan-Artikel auf olkb.com](https://olkb.com/collections/parts)
 * [Teespring Online-Shop](https://teespring.com/de/stores/qmk)
 * [Spenden Sie via OpenCollective](https://opencollective.com/qmk-firmware)
 * [Wirke mit!](https://github.com/qmk/qmk_firmware/issues)

--- a/_i18n/en/support.md
+++ b/_i18n/en/support.md
@@ -6,7 +6,7 @@ permalink: /support/
 
 # Help Support QMK
 
-* [QMK merch on olkb.com](https://olkb.com/parts)
+* [QMK merch on olkb.com](https://olkb.com/collections/parts)
 * [Teespring store](https://teespring.com/stores/qmk)
 * [Donate via OpenCollective](https://opencollective.com/qmk-firmware)
 * [Contribute!](https://github.com/qmk/qmk_firmware/issues)

--- a/_i18n/es/support.md
+++ b/_i18n/es/support.md
@@ -7,7 +7,7 @@ lang: "es"
 
 # Soporte de QMK
 
-* [Mercancía QMK en olkb.com](https://olkb.com/parts)
+* [Mercancía QMK en olkb.com](https://olkb.com/collections/parts)
 * [Tienda Teespring](https://teespring.com/stores/qmk)
 * [Donar vía OpenCollective](https://opencollective.com/qmk-firmware)
 * [¡Contribuir!](https://github.com/qmk/qmk_firmware/issues)

--- a/_i18n/fr/support.md
+++ b/_i18n/fr/support.md
@@ -7,7 +7,7 @@ lang: fr
 
 # Contribuer à QMK
 
-* [Produits dérivés QMK sur olkb.com](https://olkb.com/parts)
+* [Produits dérivés QMK sur olkb.com](https://olkb.com/collections/parts)
 * [Boutique Teespring](https://teespring.com/stores/qmk)
 * [Faites un don via OpenCollective](https://opencollective.com/qmk-firmware)
 * [Contribuez !](https://github.com/qmk/qmk_firmware/issues)

--- a/_i18n/ja/support.md
+++ b/_i18n/ja/support.md
@@ -7,7 +7,7 @@ lang: "ja"
 
 # QMK をサポートする
 
-* [olkb.com の QMK グッズ](https://olkb.com/parts)
+* [olkb.com の QMK グッズ](https://olkb.com/collections/parts)
 * [Teespring ストア](https://teespring.com/stores/qmk)
 * [OpenCollective 経由で寄付](https://opencollective.com/qmk-firmware)
 * [貢献する！](https://github.com/qmk/qmk_firmware/issues)

--- a/_i18n/pl/support.md
+++ b/_i18n/pl/support.md
@@ -7,7 +7,7 @@ permalink: /pl/support/
 
 # Pomoc Wsparcie QMK
 
-* [Sklep QMK na olkb.com](https://olkb.com/parts)
+* [Sklep QMK na olkb.com](https://olkb.com/collections/parts)
 * [Sklep Teespring](https://teespring.com/stores/qmk)
 * [Przekaż darowiznę przez OpenCollective](https://opencollective.com/qmk-firmware)
 * [Przyczyń się do rozwoju!](https://github.com/qmk/qmk_firmware/issues)


### PR DESCRIPTION
## Description

QMK merch on olkb.com link on https://qmk.fm/support/ links to 404 (https://olkb.com/parts). I think it is expected to link to https://olkb.com/collections/parts